### PR TITLE
Allow OS env variables. Change param ordering.

### DIFF
--- a/srtm.py
+++ b/srtm.py
@@ -2,13 +2,15 @@ from __future__ import print_function
 import os
 import numpy as np
 
-SRTM_DICT = {'SRTM1' : 3601, 'SRTM3' : 1201}
-SRTM_type = os.getenv('SRTM_TYPE', 'SRTM1') # Get the type of SRTM files or 
-                                            # use SRTM1 by default
-SAMPLES = SRTM_DICT[SRTM_type]
-HGTDIR = os.getenv('HGT_DIR', 'hgt')  # Get OS env. location of files, 
-                                      # or default to 'hgt', where files 
-                                      # should be kept uncompressed
+SRTM_DICT = {'SRTM1': 3601, 'SRTM3': 1201}
+
+# Get the type of SRTM files or use SRTM1 by default
+SRTM_TYPE = os.getenv('SRTM_TYPE', 'SRTM1')
+SAMPLES = SRTM_DICT[SRTM_TYPE]
+
+# put uncompressed hgt files in HGT_DIR, defaults to 'hgt'
+HGTDIR = os.getenv('HGT_DIR', 'hgt')
+
 
 def get_elevation(lat, lon):
     hgt_file = get_file_name(lat, lon)
@@ -17,6 +19,7 @@ def get_elevation(lat, lon):
     # Treat it as data void as in SRTM documentation
     # if file is absent
     return -32768
+
 
 def read_elevation_from_file(hgt_file, lat, lon):
     with open(hgt_file, 'rb') as hgt_data:
@@ -28,6 +31,7 @@ def read_elevation_from_file(hgt_file, lat, lon):
         lon_row = int(round((lon - int(lon)) * (SAMPLES - 1), 0))
         
         return elevations[SAMPLES - 1 - lat_row, lon_row].astype(int)
+
 
 def get_file_name(lat, lon):
     """
@@ -51,6 +55,7 @@ def get_file_name(lat, lon):
         return hgt_file_path
     else:
         return None
+
 
 if __name__ == '__main__':
     # Mt. Everest

--- a/srtm.py
+++ b/srtm.py
@@ -2,20 +2,23 @@ from __future__ import print_function
 import os
 import numpy as np
 
-SAMPLES = 1201  # Change this to 3601 for SRTM1
-HGTDIR = 'hgt'  # All 'hgt' files will be kept here uncompressed
+SRTM_DICT = {'SRTM1' : 3601, 'SRTM3' : 1201}
+SRTM_type = os.getenv('SRTM_TYPE', 'SRTM1') # Get the type of SRTM files or 
+                                            # use SRTM1 by default
+SAMPLES = SRTM_DICT[SRTM_type]
+HGTDIR = os.getenv('HGT_DIR', 'hgt')  # Get OS env. location of files, 
+                                      # or default to 'hgt', where files 
+                                      # should be kept uncompressed
 
-
-def get_elevation(lon, lat):
-    hgt_file = get_file_name(lon, lat)
+def get_elevation(lat, lon):
+    hgt_file = get_file_name(lat, lon)
     if hgt_file:
-        return read_elevation_from_file(hgt_file, lon, lat)
+        return read_elevation_from_file(hgt_file, lat, lon)
     # Treat it as data void as in SRTM documentation
     # if file is absent
     return -32768
 
-
-def read_elevation_from_file(hgt_file, lon, lat):
+def read_elevation_from_file(hgt_file, lat, lon):
     with open(hgt_file, 'rb') as hgt_data:
         # HGT is 16bit signed integer(i2) - big endian(>)
         elevations = np.fromfile(hgt_data, np.dtype('>i2'), SAMPLES*SAMPLES)\
@@ -26,13 +29,11 @@ def read_elevation_from_file(hgt_file, lon, lat):
         
         return elevations[SAMPLES - 1 - lat_row, lon_row].astype(int)
 
-
-def get_file_name(lon, lat):
+def get_file_name(lat, lon):
     """
     Returns filename such as N27E086.hgt, concatenated
     with HGTDIR where these 'hgt' files are kept
     """
-
     if lat >= 0:
         ns = 'N'
     elif lat < 0:
@@ -43,16 +44,16 @@ def get_file_name(lon, lat):
     elif lon < 0:
         ew = 'W'
 
-    hgt_file = "%(ns)s%(lat)02d%(ew)s%(lon)03d.hgt" % {'lat': abs(lat), 'lon': abs(lon), 'ns': ns, 'ew': ew}
+    hgt_file = "%(ns)s%(lat)02d%(ew)s%(lon)03d.hgt" % \
+               {'lat': abs(lat), 'lon': abs(lon), 'ns': ns, 'ew': ew}
     hgt_file_path = os.path.join(HGTDIR, hgt_file)
     if os.path.isfile(hgt_file_path):
         return hgt_file_path
     else:
         return None
 
-
 if __name__ == '__main__':
     # Mt. Everest
-    print(get_elevation(86.925278, 27.988056))
+    print('Mt. Everest: %d' % get_elevation(27.988056, 86.925278))
     # Kanchanjunga
-    print(get_elevation(88.146667, 27.7025))
+    print('Kanchanjunga: %d' % get_elevation(27.7025, 88.146667))


### PR DESCRIPTION
Allow OS env variables to be used as parameters for specifying the directory or the type of data. 
Change param ordering to follow more convenient `lat, lon` ordering.